### PR TITLE
Remove Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,29 +29,6 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy -- -D warnings
 
-  coverage:
-    name: Run Code Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-
-      - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
-        with:
-          cache-key: codecov
-          save-cache: ${{ github.ref_name == 'main' }}
-          tools: cargo-llvm-cov
-          components: llvm-tools-preview
-
-      - run: cargo llvm-cov --lcov --output-path lcov.info
-
-      - name: Upload to codecov.io
-        if: env.CODECOV_TOKEN
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          files: lcov.info
-
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Raytracing in Rust 🦀
 
 [![ci](https://github.com/Boshen/raytracing.rs/actions/workflows/ci.yml/badge.svg)](https://github.com/Boshen/raytracing.rs/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/Boshen/raytracing.rs/branch/main/graph/badge.svg?token=EG84H9PRFO)](https://codecov.io/gh/Boshen/raytracing.rs)
 
 Implementing ray tracing from the book [Ray Tracing from the Ground Up](https://www.amazon.com/Ray-Tracing-Ground-Kevin-Suffern/dp/1568812728)
 

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ default:
 
 # Initialize the development environment
 init:
-    cargo install cargo-watch cargo-llvm-cov cargo-codspeed
+    cargo install cargo-watch cargo-codspeed
     git config core.hooksPath .githooks
 
 # Install git pre-commit hooks
@@ -46,10 +46,6 @@ build-release:
 # Run all tests
 test:
     cargo test --release
-
-# Run tests with coverage
-coverage:
-    cargo llvm-cov --lcov --output-path lcov.info
 
 # Watch for changes and run tests
 watch-test:


### PR DESCRIPTION
## Summary
- remove the Codecov badge from the README
- delete the Codecov coverage upload job from CI
- remove local cargo-llvm-cov setup and coverage task from justfile

## Verification
- rg -n "codecov|Codecov|CODECOV|cargo-llvm-cov|llvm-cov|lcov.info|coverage" .
- git diff --check